### PR TITLE
Add robots meta if site is in private mode 

### DIFF
--- a/theme/login.php
+++ b/theme/login.php
@@ -88,11 +88,6 @@ if ( $is_iphone ) {
 do_action( 'login_enqueue_scripts' );
 do_action( 'password_protected_login_head' );
 
-
-//If the site is set to private (in privacy settings) add <meta name='robots' content='noindex,nofollow' />
-if ( '0' == get_option( 'blog_public' ) ){
-        echo("<meta name='robots' content='noindex,nofollow' />");
-}
 ?>
 
 </head>


### PR DESCRIPTION
fixes #26 by adding the correct meta if privacy is set in the reading settings. The other option would be to always have the meta tag used (as with the WordPress login.php)
