### PR TITLE
Override Login.php Template from your active theme

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -99,10 +99,18 @@ class Password_Protected_Admin {
 			$this->options_group,
 			'password_protected'
 		);
+				add_settings_field(
+					'password_protected_template',
+					__( 'Override Template', 'password-protected' ),
+					array( $this, 'password_protected_template_field' ),
+					$this->options_group,
+					'password_protected'
+				);
  		register_setting( $this->options_group, 'password_protected_status', 'intval' );
  		register_setting( $this->options_group, 'password_protected_feeds', 'intval' );
  		register_setting( $this->options_group, 'password_protected_administrators', 'intval' );
 		register_setting( $this->options_group, 'password_protected_password', array( $this, 'sanitize_password_protected_password' ) );
+		register_setting( $this->options_group, 'password_protected_template' );
  	}
 	
 	/**
@@ -151,6 +159,13 @@ class Password_Protected_Admin {
 	function password_protected_password_field() {
 		echo '<input type="password" name="password_protected_password[new]" id="password_protected_password_new" size="16" value="" autocomplete="off"> <span class="description">' . __( 'If you would like to change the password type a new one. Otherwise leave this blank.', 'password-protected' ) . '</span><br>
 			<input type="password" name="password_protected_password[confirm]" id="password_protected_password_confirm" size="16" value="" autocomplete="off"> <span class="description">' . __( 'Type your new password again.', 'password-protected' ) . '</span>';
+	}
+	
+	/**
+	 * Override Login Template
+	 */ 
+	function password_protected_template_field() {
+		echo '<input type="text" name="password_protected_template" id="password_protected_template" size="16" value="'.get_option( 'password_protected_template' ).'" autocomplete="off"> <span class="description">' . __( 'To override the login template type in the relative path to your login.php in your theme.', 'password-protected' ) . '</span>';
 	}
 	
 	/**

--- a/password-protected.php
+++ b/password-protected.php
@@ -183,7 +183,13 @@ class Password_Protected {
 		
 		// Show login form
 		if ( isset( $_REQUEST['password-protected'] ) && 'login' == $_REQUEST['password-protected'] ) {
-			include( dirname( __FILE__ ) . '/theme/login.php' );
+			$default  = dirname( __FILE__ ) . '/theme/login.php';
+			$template = get_option('password_protected_template');
+			if ( $template ) {
+				$override = get_stylesheet_directory().'/'.$template;
+				$file     = file_exists($override) ? $override : $default;
+			}else $file = $default;
+			include( $file );
 			exit();
 		} else {
 			$query = array(


### PR DESCRIPTION
This adds the field Override Template option to admin and updates maybe_show_login to load the template specified from your active theme. Checks for file to make sure it exists first, if not will default back to plugin template. Path is relative to your theme's root.

![screenshot 2013-10-16 18 22 41](https://f.cloud.github.com/assets/12783/1348548/bc1bab8c-36ca-11e3-9b39-ac2bce6e2b1a.png)
