### PR TITLE
Remember me option

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -128,6 +128,14 @@ class Password_Protected_Admin {
 			$this->options_group,
 			'password_protected'
 		);
+		
+		add_settings_field(
+			'password_protected_allow_remember_me',
+			__( 'Allow Remember me', 'password-protected' ),
+			array( $this, 'password_protected_allow_remember_me_field' ),
+			$this->options_group,
+			'password_protected'
+		);
 
 		register_setting( $this->options_group, 'password_protected_status', 'intval' );
 		register_setting( $this->options_group, 'password_protected_feeds', 'intval' );
@@ -135,7 +143,8 @@ class Password_Protected_Admin {
 		register_setting( $this->options_group, 'password_protected_users', 'intval' );
 		register_setting( $this->options_group, 'password_protected_password', array( $this, 'sanitize_password_protected_password' ) );
 		register_setting( $this->options_group, 'password_protected_allowed_ip_addresses', array( $this, 'sanitize_ip_addresses' ) );
-
+		register_setting( $this->options_group, 'password_protected_allow_remember_me', 'boolval' );
+		
 	}
 
 	/**
@@ -248,6 +257,15 @@ class Password_Protected_Admin {
 		echo '<textarea name="password_protected_allowed_ip_addresses" id="password_protected_allowed_ip_addresses" rows="3" class="large-text" />' . get_option( 'password_protected_allowed_ip_addresses' ) . '</textarea>';
 		echo '<p class="description">' . esc_html__( 'Enter one IP address per line.', 'password-protected' ) . ' ' . esc_html( sprintf( __( 'Your IP is address %s.', 'password-protected' ), $_SERVER['REMOTE_ADDR'] ) ) . '</p>';
 
+	}
+	
+	/**
+	 * Remember Me Field
+	 */
+	public function password_protected_allow_remember_me_field() {
+		
+		echo '<label><input name="password_protected_allow_remember_me" id="password_protected_allow_remember_me" type="checkbox" value="1" ' . checked( 1, get_option( 'password_protected_allow_remember_me' ), false ) . ' /> ' . __( 'Allow Remember me', 'password-protected' ) . '</label>';
+		
 	}
 
 	/**

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -136,6 +136,14 @@ class Password_Protected_Admin {
 			$this->options_group,
 			'password_protected'
 		);
+		
+		add_settings_field(
+			'password_protected_remember_me_lifetime',
+			__( 'Remember for this many days', 'password-protected' ),
+			array( $this, 'password_protected_remember_me_lifetime_field' ),
+			$this->options_group,
+			'password_protected'
+		);
 
 		register_setting( $this->options_group, 'password_protected_status', 'intval' );
 		register_setting( $this->options_group, 'password_protected_feeds', 'intval' );
@@ -144,6 +152,7 @@ class Password_Protected_Admin {
 		register_setting( $this->options_group, 'password_protected_password', array( $this, 'sanitize_password_protected_password' ) );
 		register_setting( $this->options_group, 'password_protected_allowed_ip_addresses', array( $this, 'sanitize_ip_addresses' ) );
 		register_setting( $this->options_group, 'password_protected_allow_remember_me', 'boolval' );
+		register_setting( $this->options_group, 'password_protected_remember_me_lifetime', 'intval' );
 		
 	}
 
@@ -264,7 +273,16 @@ class Password_Protected_Admin {
 	 */
 	public function password_protected_allow_remember_me_field() {
 		
-		echo '<label><input name="password_protected_allow_remember_me" id="password_protected_allow_remember_me" type="checkbox" value="1" ' . checked( 1, get_option( 'password_protected_allow_remember_me' ), false ) . ' /> ' . __( 'Allow Remember me', 'password-protected' ) . '</label>';
+		echo '<label><input name="password_protected_allow_remember_me" id="password_protected_allow_remember_me" type="checkbox" value="1" ' . checked( 1, get_option( 'password_protected_allow_remember_me' ), false ) . ' /></label>';
+		
+	}
+	
+	/**
+	 * Remember Me lifetime field
+	 */
+	public function password_protected_remember_me_lifetime_field() {
+		
+		echo '<label><input name="password_protected_remember_me_lifetime" id="password_protected_remember_me_lifetime" type="number" value="' . get_option( 'password_protected_remember_me_lifetime', 14 ) . '" /></label>';
 		
 	}
 

--- a/password-protected.php
+++ b/password-protected.php
@@ -236,6 +236,17 @@ class Password_Protected {
 		return explode( "\n", get_option( 'password_protected_allowed_ip_addresses' ) );
 
 	}
+	
+	/**
+	 * Allow the remember me function
+	 *
+	 * @return  boolean         True/false.
+	 */
+	public function allow_remember_me() {
+		
+		return (bool) get_option( 'password_protected_allow_remember_me' );
+		
+	}
 
 	/**
 	 * Encrypt Password
@@ -283,7 +294,13 @@ class Password_Protected {
 			// If correct password...
 			if ( ( $this->encrypt_password( $password_protected_pwd ) == $pwd && $pwd != '' ) || apply_filters( 'password_protected_process_login', false, $password_protected_pwd ) ) {
 
-				$this->set_auth_cookie();
+				$remember = isset ( $_REQUEST['password_protected_rememberme'] ) ? boolval( $_REQUEST['password_protected_rememberme'] ) : false;
+				if ( ! $this->allow_remember_me() )
+				{
+					$remember = false;
+				}
+			
+				$this->set_auth_cookie( $remember );
 				$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : '';
 				$redirect_to = apply_filters( 'password_protected_login_redirect', $redirect_to );
 
@@ -573,7 +590,7 @@ class Password_Protected {
 	public function set_auth_cookie( $remember = false, $secure = '') {
 
 		if ( $remember ) {
-			$expiration = $expire = current_time( 'timestamp' ) + apply_filters( 'password_protected_auth_cookie_expiration', 1209600, $remember );
+			$expiration = $expire = current_time( 'timestamp' ) + apply_filters( 'password_protected_auth_cookie_expiration', get_option('password_protected_remember_me_lifetime', 14) * 86400, $remember );
 		} else {
 			$expiration = current_time( 'timestamp' ) + apply_filters( 'password_protected_auth_cookie_expiration', 172800, $remember );
 			$expire = 0;

--- a/theme/password-protected-login.php
+++ b/theme/password-protected-login.php
@@ -107,9 +107,11 @@ do_action( 'password_protected_login_head' );
 			<label for="password_protected_pass"><?php _e( 'Password', 'password-protected' ) ?><br />
 			<input type="password" name="password_protected_pwd" id="password_protected_pass" class="input" value="" size="20" tabindex="20" /></label>
 		</p>
-		<!--
-		<p class="forgetmenot"><label for="rememberme"><input name="rememberme" type="checkbox" id="rememberme" value="forever" tabindex="90"<?php checked( ! empty( $_POST['rememberme'] ) ); ?> /> <?php esc_attr_e( 'Remember Me', 'password-protected' ); ?></label></p>
-		-->
+
+		<?php if ($Password_Protected->allow_remember_me()) : ?>
+		<p class="forgetmenot"><label for="rememberme"><input name="password_protected_rememberme" type="checkbox" id="password_protected_rememberme" value="1" tabindex="90" /> <?php esc_attr_e( 'Remember Me', 'password-protected' ); ?></label></p>
+		<?php endif; ?>
+			
 		<p class="submit">
 			<input type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="<?php esc_attr_e( 'Log In', 'password-protected' ); ?>" tabindex="100" />
 			<input type="hidden" name="testcookie" value="1" />


### PR DESCRIPTION
This implements a "Remember me" field on the login page, if the admin chooses to enable this function.
Most of this was already in the code, so the only changes are the following:

- Add two new settings (one to enable the functionality, the other one to define the number of days a remember me cookie is valid)
- Add a checkbox on the login page when this option is enabled
- Changes to the login process and the cookie expiration date

This should fix #11, however there are a few issues that I can think of:

- Disabling this option does not require users to re-login
- Changing the number of days until expiration does not require users to re-login

For me, it works (tm), however YMMV.