### PR TITLE
Theme: add filter to allow customizing "Password"

### DIFF
--- a/theme/password-protected-login.php
+++ b/theme/password-protected-login.php
@@ -104,7 +104,7 @@ do_action( 'password_protected_login_head' );
 
 	<form name="loginform" id="loginform" action="<?php echo esc_url( $Password_Protected->login_url() ); ?>" method="post">
 		<p>
-			<label for="password_protected_pass"><?php _e( 'Password', 'password-protected' ) ?><br />
+			<label for="password_protected_pass"><?php echo apply_filters( 'password_protected_login_password_title', __( 'Password', 'password-protected' ) ); ?><br />
 			<input type="password" name="password_protected_pwd" id="password_protected_pass" class="input" value="" size="20" tabindex="20" /></label>
 		</p>
 


### PR DESCRIPTION
I've added a new filter, `password_protected_login_password_title`, allowing you to change the default "Password" label that appears above the password field. It allows one to customize just that part of the form without having to make a completely new theme.

One could use that filter to offer a tip to their readers about the password they are expected to enter, for example.