### PR TITLE
Added 'is_active()' condition

### DIFF
--- a/password-protected.php
+++ b/password-protected.php
@@ -802,7 +802,7 @@ class Password_Protected {
 	public function only_allow_logged_in_rest_access( $access ) {
 
 		// If user is not logged in
-		if ( ! $this->is_user_logged_in() && ! is_user_logged_in() && ! (bool) get_option( 'password_protected_rest' ) ) {
+		if ( $this->is_active() && ! $this->is_user_logged_in() && ! is_user_logged_in() && ! (bool) get_option( 'password_protected_rest' ) ) {
 			return new WP_Error( 'rest_cannot_access', __( 'Only authenticated users can access the REST API.', 'password-protected' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 


### PR DESCRIPTION
Restrict REST-API-access only if password protection is active 

This will fix this ContactForm 7 issue: https://github.com/benhuson/password-protected/issues/113