### PR TITLE
let developers override the capability needed to see the options page

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -43,7 +43,8 @@ class Password_Protected_Admin {
 	 */
 	public function admin_menu() {
 
-		$this->settings_page_id = add_options_page( __( 'Password Protected', 'password-protected' ), __( 'Password Protected', 'password-protected' ), 'manage_options', 'password-protected', array( $this, 'settings_page' ) );
+		$capability = apply_filters( 'password-protected-options-page-capability', 'manage_options' );
+		$this->settings_page_id = add_options_page( __( 'Password Protected', 'password-protected' ), __( 'Password Protected', 'password-protected' ), $capability, 'password-protected', array( $this, 'settings_page' ) );
 		add_action( 'load-' . $this->settings_page_id, array( $this, 'add_help_tabs' ), 20 );
 
 	}


### PR DESCRIPTION
I needed to have this flexibility as I had a multisite with different roles. 
To make it work, you also need to add

```
	add_filter( 'option_page_capability_password-protected', function ( $capability ) {
		return 'manage_password_protection';
	} );
```

to your theme

Don't know if you agree on the approach or would prefer a different one