### PR TITLE
allow CIDR/Netmask notation, allow commments after IP

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -232,9 +232,42 @@ class Password_Protected_Admin {
 	 */
 	private function validate_ip_address( $ip_address ) {
 
-		return filter_var( $ip_address, FILTER_VALIDATE_IP );
+		$ip = trim(explode("#",$ip_address)[0]); // allow for comments after ip
+
+		if ($this->is_ip($ip)) {
+			return trim($ip_address);
+		}
+		else {
+			return "";
+		}
 
 	}
+
+	/**
+	 * Is it a valid IP address? v4/v6 with subnet range.
+	 *
+	 * @param string $ip_address IP Address to check.
+	 *
+	 * @return bool True if its a valid IP address.
+	 */
+	private function  is_ip( $ip_address ) {
+		// very basic validation of ranges.
+		if ( strpos( $ip_address, '/' ) ) {
+			$ip_parts = explode( '/', $ip_address );
+			if ( empty( $ip_parts[1] ) || ! is_numeric( $ip_parts[1] ) || strlen( $ip_parts[1] ) > 3 ) {
+				return false;
+			}
+			$ip_address = $ip_parts[0];
+		}
+
+		// confirm IP part is a valid IPv6 or IPv4 IP.
+		if ( empty( $ip_address ) || ! inet_pton( stripslashes( $ip_address ) ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
 
 	/**
 	 * Password Protected Section
@@ -282,9 +315,9 @@ class Password_Protected_Admin {
 	 */
 	public function password_protected_allowed_ip_addresses_field() {
 
-		echo '<textarea name="password_protected_allowed_ip_addresses" id="password_protected_allowed_ip_addresses" rows="3" class="large-text" />' . get_option( 'password_protected_allowed_ip_addresses' ) . '</textarea>';
+		echo '<textarea name="password_protected_allowed_ip_addresses" id="password_protected_allowed_ip_addresses" rows="20" class="large-text" />' . get_option( 'password_protected_allowed_ip_addresses' ) . '</textarea>';
 
-		echo '<p class="description">' . esc_html__( 'Enter one IP address per line.', 'password-protected' );
+		echo '<p class="description">' . esc_html__( 'Enter one IP address per line. (IP/CIDR netmask notation is allowed eg. 127.0.0.0/24, comments are allowed after IP eg. 127.0.0.1 #Comment)', 'password-protected' );
 		if ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
 			echo ' ' . esc_html( sprintf( __( 'Your IP is address %s.', 'password-protected' ), $_SERVER['REMOTE_ADDR'] ) );
 		}

--- a/password-protected.php
+++ b/password-protected.php
@@ -215,6 +215,27 @@ class Password_Protected {
 	}
 
 	/**
+	 * Check if a given ip is in a network.
+	 * Source: https://gist.github.com/tott/7684443
+	 *
+	 * @param  string $ip    IP to check in IPV4 format eg. 127.0.0.1.
+	 * @param  string $range IP/CIDR netmask eg. 127.0.0.0/24, also 127.0.0.1 is accepted and /32 assumed.
+	 * @return boolean true if the ip is in this range / false if not.
+	 */
+	public static function ip_in_range( $ip, $range ) {
+		if ( strpos( $range, '/' ) === false ) {
+			$range .= '/32';
+		}
+		// $range is in IP/CIDR format eg 127.0.0.1/24
+		list( $range, $netmask ) = explode( '/', $range, 2 );
+		$range_decimal           = ip2long( $range );
+		$ip_decimal              = ip2long( $ip );
+		$wildcard_decimal        = pow( 2, ( 32 - $netmask ) ) - 1;
+		$netmask_decimal         = ~ $wildcard_decimal;
+		return ( ( $ip_decimal & $netmask_decimal ) === ( $range_decimal & $netmask_decimal ) );
+	}
+
+	/**
 	 * Allow IP Addresses
 	 *
 	 * If user has a valid email address, return false to disable password protection.
@@ -226,8 +247,18 @@ class Password_Protected {
 
 		$ip_addresses = $this->get_allowed_ip_addresses();
 
-		if ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], $ip_addresses ) ) {
-			$bool = false;
+		if ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
+
+			$remote_ip = $_SERVER['REMOTE_ADDR'];
+
+			// iterate through the allow list.
+			foreach ( $ip_addresses as $line ) {
+				$line = trim(explode("#",$line)[0]); // allow for comments after ip
+				if ( $this->ip_in_range( $remote_ip, $line ) ) {
+					$bool = false;
+				}
+			}
+
 		}
 
 		return $bool;


### PR DESCRIPTION
I added some extended ability to allow for CIDR/Netmask notations on IP address.  I also added the ability to include a comment after the IP, to help keep track of the IPs.  My client has a long list of IPs needed for access.

