### PR TITLE
Add a Nocache header to the login page redirect to prevent the browser from caching the redirect page

### DIFF
--- a/password-protected.php
+++ b/password-protected.php
@@ -384,6 +384,7 @@ class Password_Protected {
 				$redirect_to = add_query_arg( 'redirect_to', urlencode( $redirect_to_url ), $redirect_to );
 			}
 
+			nocache_headers();
 			wp_redirect( $redirect_to );
 			exit();
 


### PR DESCRIPTION
This prevents the user's browser from caching the redirect and making the browser think that redirect page is the original page that the user wanted to go to.

This fixes: https://github.com/benhuson/password-protected/issues/169 and https://github.com/benhuson/password-protected/issues/159