### PR TITLE
Update readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ You can also submit suggested enhancements if you like.
 If you can, please [fork the code](https://github.com/benhuson/password-protected) and submit a pull request via GitHub. If you're not comfortable using Git, then please just submit it to the issues link above.
 
 = How can I translate this plugin? =
-If you would like to translate this plugin you can easily contribute at the [Translating WordPress](https://translate.wordpress.org/projects/wp-plugins/password-protected/) page. The stable plugin needs to be 95% translated for a language file to be available to download/update via WordPress.
+If you would like to translate this plugin you can easily contribute at the [Translating WordPress](https://translate.wordpress.org/projects/wp-plugins/password-protected/) page. The stable plugin needs to be 90% translated for a language file to be available to download/update via WordPress.
 
 == Screenshots ==
 


### PR DESCRIPTION
Translator Handbook wrote 90% of strings need to translate to make a download available instead of 95%.
https://make.wordpress.org/polyglots/handbook/frequently-asked-questions/#strings-are-validated-when-are-they-taken-into-account-for-download

The actual translator page writes as same.
https://translate.wordpress.org/locale/ja/default/wp-plugins/password-protected/