### PR TITLE
Fix redirect loop when entering password via get query parameters

### DIFF
--- a/password-protected.php
+++ b/password-protected.php
@@ -321,7 +321,7 @@ class Password_Protected {
 					$this->safe_redirect( remove_query_arg( 'password-protected', $redirect_to ) );
 					exit;
 				} elseif ( isset( $_GET['password_protected_pwd'] ) ) {
-					$this->safe_redirect( remove_query_arg( 'password-protected' ) );
+                    $this->safe_redirect( remove_query_arg( ['password_protected_pwd', 'password-protected'] ) );
 					exit;
 				}
 


### PR DESCRIPTION
I believe that since the changes in #166 we sometimes see a redirect loop when users use the password in the url.

This patch tries to fix that.