### PR TITLE
Add customizable message above password form.

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -163,6 +163,14 @@ class Password_Protected_Admin {
 			'password_protected'
 		);
 
+		add_settings_field(
+			'password_protected_message',
+			__( 'Message to display above the password form', 'password-protected' ),
+			array( $this, 'password_protected_message_field' ),
+			$this->options_group,
+			'password_protected'
+		);
+
 		register_setting( $this->options_group, 'password_protected_status', 'intval' );
 		register_setting( $this->options_group, 'password_protected_feeds', 'intval' );
 		register_setting( $this->options_group, 'password_protected_rest', 'intval' );
@@ -172,6 +180,7 @@ class Password_Protected_Admin {
 		register_setting( $this->options_group, 'password_protected_allowed_ip_addresses', array( $this, 'sanitize_ip_addresses' ) );
 		register_setting( $this->options_group, 'password_protected_remember_me', 'boolval' );
 		register_setting( $this->options_group, 'password_protected_remember_me_lifetime', 'intval' );
+		register_setting( $this->options_group, 'password_protected_message', 'wp_filter_post_kses' );
 
 	}
 
@@ -308,6 +317,24 @@ class Password_Protected_Admin {
 	public function password_protected_remember_me_lifetime_field() {
 
 		echo '<label><input name="password_protected_remember_me_lifetime" id="password_protected_remember_me_lifetime" type="number" value="' . get_option( 'password_protected_remember_me_lifetime', 14 ) . '" /></label>';
+
+	}
+
+	/**
+	 * Output the form element to collect the message input.
+	 *
+	 * @since   3.0
+	 *
+	 * @return string HTML to display.
+	 */
+	public function password_protected_message_field() {
+
+		$settings = apply_filters( 'password_protected_message_editor_settings', array(
+			'textarea_rows' => 5,
+		) );
+		$saved_option = wp_unslash( get_option( 'password_protected_message' ) );
+
+		wp_editor( $saved_option, 'password_protected_message', $settings );
 
 	}
 

--- a/password-protected.php
+++ b/password-protected.php
@@ -70,6 +70,7 @@ class Password_Protected {
 		add_filter( 'rest_authentication_errors', array( $this, 'only_allow_logged_in_rest_access' ) );
 		add_action( 'init', array( $this, 'compat' ) );
 		add_action( 'password_protected_login_messages', array( $this, 'login_messages' ) );
+		add_action( 'password_protected_before_login_form', array( $this, 'display_custom_message' ) );
 		add_action( 'login_enqueue_scripts', array( $this, 'load_theme_stylesheet' ), 5 );
 
 		// Available from WordPress 4.3+
@@ -738,6 +739,22 @@ class Password_Protected {
 				echo '<p class="message">' . apply_filters( 'password_protected_login_messages', $messages ) . "</p>\n";
 			}
 
+		}
+
+	}
+
+	/**
+	 * Add a message above the "password protected" form, if set.
+	 *
+	 * @since   3.0
+	 *
+	 * @return string HTML to display.
+	 */
+	function display_custom_message() {
+
+		$message = get_option( 'password_protected_message' );
+		if ( $message ) {
+			echo apply_filters( 'the_content', wp_unslash( $message ) );
 		}
 
 	}


### PR DESCRIPTION
* Add an input so that site admins can easily add a custom message above the password entry form.
![pp-add-form-field](https://user-images.githubusercontent.com/1391994/147976208-d5db3093-b0a5-4329-ab24-9068dc27ce2c.png)

* Output the custom message on the `password_protected_before_login_form` hook.
![pp-output-message](https://user-images.githubusercontent.com/1391994/147976238-1b19f172-741e-444f-b4b7-fa6d0ebf70fa.png)

